### PR TITLE
Fix how URLs are computed with relative paths

### DIFF
--- a/src/spherexlander/parsers/pipelinemodule/datamodel.py
+++ b/src/spherexlander/parsers/pipelinemodule/datamodel.py
@@ -125,7 +125,10 @@ class SpherexPipelineModuleMetadata(DocumentMetadata):
     def dashboard_url(self) -> Optional[str]:
         """URL to the edition dashboard."""
         if self.canonical_url:
-            return urllib.parse.urljoin(self.canonical_url, "/v")
+            if self.canonical_url.endswith("/"):
+                return f"{self.canonical_url}v/"
+            else:
+                return f"{self.canonical_url}/v/"
         else:
             return None
 


### PR DESCRIPTION
Before we were trying to add extra relative paths to a base URL with `urllib.parse.urljoin`, but this is the wrong approach because it replaces the entire path component of the base URL with the new URL. So instead we're directly relative paths to the root URLs.