### PR TITLE
Require lander >= 2.0.0a8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     importlib_metadata; python_version < "3.8"
-    lander >= 2.0.0a7
+    lander >= 2.0.0a8
     python-dateutil
 
 [options.packages.find]


### PR DESCRIPTION
This ensures we're using a version of lander that pins its Pydantic
dependency < 2.0.