### PR TITLE
Require lander 2.0.0a8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     importlib_metadata; python_version < "3.8"
-    lander >= 2.0.0a8
+    lander == 2.0.0a8
     python-dateutil
 
 [options.packages.find]


### PR DESCRIPTION
This is the last release that supports Pydantic v1. We'll pin to this
release while we upgrade the plugin to support the new release that uses
Pydantic v2.