### PR TITLE
Migrate to Pydantic 2 with lander 2.0.0a14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Python install
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,12 +29,11 @@ include_package_data = True
 package_dir =
     = src
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.11
 setup_requires =
     setuptools_scm
 install_requires =
-    importlib_metadata; python_version < "3.8"
-    lander == 2.0.0a8
+    lander >= 2.0.0a11
     python-dateutil
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ python_requires = >=3.11
 setup_requires =
     setuptools_scm
 install_requires =
-    lander >= 2.0.0a11
+    lander >= 2.0.0a14
     python-dateutil
 
 [options.packages.find]

--- a/src/spherexlander/__init__.py
+++ b/src/spherexlander/__init__.py
@@ -3,13 +3,7 @@
 
 __all__ = ["__version__"]
 
-import sys
-
-if sys.version_info < (3, 8):
-    from importlib_metadata import PackageNotFoundError, version
-else:
-    from importlib.metadata import PackageNotFoundError, version
-
+from importlib.metadata import PackageNotFoundError, version
 
 __version__: str
 """The package version string (PEP 440 / SemVer compatible)."""

--- a/src/spherexlander/parsers/pipelinemodule/parser.py
+++ b/src/spherexlander/parsers/pipelinemodule/parser.py
@@ -20,7 +20,9 @@ __all__ = ["SpherexPipelineModuleParser"]
 logger = getLogger(__name__)
 
 
-class SpherexPipelineModuleParser(SpherexParser):
+class SpherexPipelineModuleParser(
+    SpherexParser[SpherexPipelineModuleMetadata]
+):
     """Lander metadata parser for SPHEREx Module Specification (MS)
     documents.
     """

--- a/src/spherexlander/parsers/projectmanagement/parser.py
+++ b/src/spherexlander/parsers/projectmanagement/parser.py
@@ -12,7 +12,9 @@ __all__ = ["SpherexProjectManagementParser"]
 logger = getLogger(__name__)
 
 
-class SpherexProjectManagementParser(SpherexParser):
+class SpherexProjectManagementParser(
+    SpherexParser[SpherexProjectManagementMetadata]
+):
     """Lander metadata parser for SPHEREx Project Management (PM) documents."""
 
     def extract_metadata(self) -> SpherexProjectManagementMetadata:

--- a/src/spherexlander/parsers/spherexdata.py
+++ b/src/spherexlander/parsers/spherexdata.py
@@ -17,22 +17,22 @@ class SpherexMetadata(DocumentMetadata):
     Individual documents can inherit and add to this base set of metadata.
     """
 
-    git_commit_sha: Optional[str]
+    git_commit_sha: Optional[str] = None
     """Git Commit SHA."""
 
-    git_ref: Optional[str]
+    git_ref: Optional[str] = None
     """Git ref (branch or tag)."""
 
-    git_ref_type: Optional[str]
+    git_ref_type: Optional[str] = None
     """Git ref type (branch or tag)."""
 
-    ci_build_id: Optional[str]
+    ci_build_id: Optional[str] = None
     """CI build ID."""
 
-    ci_build_url: Optional[HttpUrl]
+    ci_build_url: Optional[HttpUrl] = None
     """URL of the CI job/build."""
 
-    github_slug: Optional[str]
+    github_slug: Optional[str] = None
     """The slug (``org/name``) of the repository on GitHub."""
 
     @property

--- a/src/spherexlander/parsers/spherexdata.py
+++ b/src/spherexlander/parsers/spherexdata.py
@@ -40,7 +40,7 @@ class SpherexMetadata(DocumentMetadata):
         """The GitHub web URL corresponding to the branch or tag."""
         # Ensure sufficient data and GitHub hosting
         if self.repository_url and self.github_slug and self.git_ref:
-            repo_url = self.repository_url
+            repo_url = str(self.repository_url)
             if not repo_url.endswith("/"):
                 repo_url = f"{repo_url}/"
             return urllib.parse.urljoin(repo_url, f"tree/{self.git_ref}")
@@ -52,7 +52,7 @@ class SpherexMetadata(DocumentMetadata):
         """The GitHub web URL corresponding to the commit."""
         # Ensure sufficient data and GitHub hosting
         if self.repository_url and self.github_slug and self.git_commit_sha:
-            repo_url = self.repository_url
+            repo_url = str(self.repository_url)
             if not repo_url.endswith("/"):
                 repo_url = f"{repo_url}/"
             return urllib.parse.urljoin(
@@ -65,10 +65,11 @@ class SpherexMetadata(DocumentMetadata):
     def dashboard_url(self) -> Optional[str]:
         """URL to the edition dashboard."""
         if self.canonical_url:
-            if self.canonical_url.endswith("/"):
-                return f"{self.canonical_url}v/"
+            canonical_url = str(self.canonical_url)
+            if canonical_url.endswith("/"):
+                return f"{canonical_url}v/"
             else:
-                return f"{self.canonical_url}/v/"
+                return f"{canonical_url}/v/"
         else:
             return None
 

--- a/src/spherexlander/parsers/spherexparser.py
+++ b/src/spherexlander/parsers/spherexparser.py
@@ -8,7 +8,12 @@ from logging import getLogger
 from typing import Any, List, Optional
 
 import dateutil.parser
-from lander.ext.parser import CiPlatform, Contributor, Parser
+from lander.ext.parser import (
+    CiPlatform,
+    Contributor,
+    DocumentMetadataT,
+    Parser,
+)
 from lander.ext.parser.pandoc import convert_text
 from lander.ext.parser.texutils.extract import (
     LaTeXCommand,
@@ -22,7 +27,7 @@ __all__ = ["SpherexParser", "KVOptionMap"]
 logger = getLogger(__name__)
 
 
-class SpherexParser(Parser):
+class SpherexParser(Parser[DocumentMetadataT]):
     """A base parser for documents that use the ``spherex`` tex class.
 
     Parsers for specific document types can inherit from this base class

--- a/src/spherexlander/parsers/ssdcdp/parser.py
+++ b/src/spherexlander/parsers/ssdcdp/parser.py
@@ -12,7 +12,7 @@ __all__ = ["SpherexSsdcDpParser"]
 logger = getLogger(__name__)
 
 
-class SpherexSsdcDpParser(SpherexParser):
+class SpherexSsdcDpParser(SpherexParser[SpherexSsdcDpMetadata]):
     """Lander metadata parser for SPHEREx SSDC-DP documents."""
 
     def extract_metadata(self) -> SpherexSsdcDpMetadata:

--- a/src/spherexlander/parsers/ssdcif/parser.py
+++ b/src/spherexlander/parsers/ssdcif/parser.py
@@ -18,7 +18,7 @@ __all__ = ["SpherexSsdcIfParser"]
 logger = getLogger(__name__)
 
 
-class SpherexSsdcIfParser(SpherexParser):
+class SpherexSsdcIfParser(SpherexParser[SpherexSsdcIfMetadata]):
     """Lander metadata parser for SPHEREx SSDC-IF documents."""
 
     def extract_metadata(self) -> SpherexSsdcIfMetadata:

--- a/src/spherexlander/parsers/ssdcop/parser.py
+++ b/src/spherexlander/parsers/ssdcop/parser.py
@@ -12,7 +12,7 @@ __all__ = ["SpherexSsdcOpParser"]
 logger = getLogger(__name__)
 
 
-class SpherexSsdcOpParser(SpherexParser):
+class SpherexSsdcOpParser(SpherexParser[SpherexSsdcOpMetadata]):
     """Lander metadata parser for SPHEREx SSDC-OP documents."""
 
     def extract_metadata(self) -> SpherexSsdcOpMetadata:

--- a/src/spherexlander/parsers/ssdctn/parser.py
+++ b/src/spherexlander/parsers/ssdctn/parser.py
@@ -12,7 +12,7 @@ __all__ = ["SpherexSsdcTnParser"]
 logger = getLogger(__name__)
 
 
-class SpherexSsdcTnParser(SpherexParser):
+class SpherexSsdcTnParser(SpherexParser[SpherexSsdcTnMetadata]):
     """Lander metadata parser for SPHEREx SSDC-TN documents."""
 
     def extract_metadata(self) -> SpherexSsdcTnMetadata:

--- a/src/spherexlander/parsers/ssdctr/parser.py
+++ b/src/spherexlander/parsers/ssdctr/parser.py
@@ -18,7 +18,7 @@ __all__ = ["SpherexSsdcTrParser"]
 logger = getLogger(__name__)
 
 
-class SpherexSsdcTrParser(SpherexParser):
+class SpherexSsdcTrParser(SpherexParser[SpherexSsdcTrMetadata]):
     """Lander metadata parser for SPHEREx SSDC-TR documents."""
 
     def extract_metadata(self) -> SpherexSsdcTrMetadata:

--- a/src/spherexlander/themes/spherex/theme.py
+++ b/src/spherexlander/themes/spherex/theme.py
@@ -31,3 +31,6 @@ class SpherexTheme(ThemePlugin):
         files in the site.
         """
         return Path(__file__).parent.joinpath("templates")
+
+    def run_post_build(self, output_dir: Path) -> None:
+        pass

--- a/tests/test_parser_pipelinemodule.py
+++ b/tests/test_parser_pipelinemodule.py
@@ -34,8 +34,10 @@ def test_demodoc() -> None:
 
     assert len(m.authors) == 4
     assert len(m.other_authors) == 2
+    assert m.ipac_lead is not None
     assert m.ipac_lead.name == "Francis Carrillo"
     assert m.ipac_lead.email == "francis@example.com"
+    assert m.spherex_poc is not None
     assert m.spherex_poc.name == "Ursula Gomez"
     assert m.spherex_poc.email == "ursula@example.com"
     assert m.authors[2].name == "Stephanie Lowe"

--- a/tests/test_parser_projectmanagement.py
+++ b/tests/test_parser_projectmanagement.py
@@ -33,6 +33,7 @@ def test_demo() -> None:
     assert m.document_handle_prefix == "SSDC-PM"
     assert len(m.authors) == 3
     assert len(m.other_authors) == 2
+    assert m.ipac_lead is not None
     assert m.ipac_lead.name == "Example Lead"
     assert m.ipac_lead.email == "person@example.edu"
     assert m.spherex_poc is None
@@ -40,5 +41,6 @@ def test_demo() -> None:
     assert m.authors[1].email == "galileo@example.com"
     assert m.authors[2].name == "Isaac Newton"
     assert m.authors[2].email is None
+    assert m.approval is not None
     assert m.approval.name == "Approver Name"
     assert m.approval.date == "2021-12-10"

--- a/tests/test_parser_ssdc_tr.py
+++ b/tests/test_parser_ssdc_tr.py
@@ -31,8 +31,10 @@ def test_tr_req() -> None:
     assert m.document_handle_prefix == "SSDC-TR"
     assert len(m.authors) == 1
     assert len(m.other_authors) == 0
+    assert m.ipac_lead is not None
     assert m.ipac_lead.name == "Galileo Galilei"
     assert m.ipac_lead.email == "galileo@example.com"
+    assert m.approval is not None
     assert m.approval.name == "Edwin Hubble"
     assert m.approval.date == "2021-01-01"
     assert m.ipac_jira_id == "SVV-999"
@@ -64,8 +66,10 @@ def test_tr_va() -> None:
     assert m.document_handle_prefix == "SSDC-TR"
     assert len(m.authors) == 1
     assert len(m.other_authors) == 0
+    assert m.ipac_lead is not None
     assert m.ipac_lead.name == "Galileo Galilei"
     assert m.ipac_lead.email == "galileo@example.com"
+    assert m.approval is not None
     assert m.approval.name == "Edwin Hubble"
     assert m.approval.date == "2021-01-01"
     assert m.ipac_jira_id == "SVV-999"


### PR DESCRIPTION
This migrates spherex-lander-plugin to use Lander 2.0.0a14. This version of Lander adopts Pydantic 2. Migrating to Pydantic 2 now is useful for updating the SPHEREx documentation portal which uses the Pydantic data models from this plugin to parse metadata provided by individual documents.

This change also now requires Python 3.11 or later. I'll make a corresponding update to https://github.com/SPHEREx/spherex-doc-workflows/ to use Python 3.12 when building landing pages.